### PR TITLE
address a few issues in the chrome lighthouse audit

### DIFF
--- a/src/components/footer/Footer.jsx
+++ b/src/components/footer/Footer.jsx
@@ -39,6 +39,7 @@ const Footer = () => (
               as="a"
               href={social.link}
               target="_blank"
+              rel="noopener noreferrer"
               key={index}
               margin="0 10px"
             >

--- a/src/components/layout/landing-layout/LandingLayout.jsx
+++ b/src/components/layout/landing-layout/LandingLayout.jsx
@@ -16,8 +16,9 @@ import Footer from "../../footer/Footer"
 
 const LandingLayout = ({ children, page }) => (
   <>
-    <Helmet>
+    <Helmet htmlAttributes={{ lang: "en"}} >
       <meta charSet="utf-8" />
+      <meta name="description" content="Helping new talent into the tech world" />
       <title>Hack Your Future Belgium</title>
       <link rel="canonical" href="https://hackyourfuture.be/" />
       <link

--- a/src/components/page-sections/program-skills/ProgramSkills.jsx
+++ b/src/components/page-sections/program-skills/ProgramSkills.jsx
@@ -35,6 +35,7 @@ const ProgramSkills = () => (
               as="a"
               href="https://home.hackyourfuture.be/curriculum#the-modules"
               target="_blank"
+              rel="noopener noreferrer"
             >
               {data.cta1}
             </Button>
@@ -44,6 +45,7 @@ const ProgramSkills = () => (
               as="a"
               href="https://docs.google.com/forms/d/e/1FAIpQLSef3OH8546MJNllcvrv7KomHelqzrKNpnLRVbI1ZqbeajnluA/viewform"
               target="_blank"
+              rel="noopener noreferrer"
             >
               {data.cta2}
             </Button>

--- a/src/components/ui/image/style.js
+++ b/src/components/ui/image/style.js
@@ -3,7 +3,8 @@ import styled from "styled-components"
 
 export const StyledImage = styled(
   ({ width, height, objectFit, radius, alt, ...rest }) => (
-    <img alt={alt} {...rest} />
+    // this empty string is to prevent screenreaders from reading the source of the img, which is the default behavior in some systems
+    <img alt={alt || ''} {...rest} />
   )
 )`
   width: ${({ width }) => width};


### PR DESCRIPTION
a few issues got flagged in the lighthouse audit, and are addressed in this commit:

- lack of "lang" attribute in the html element
- lack of "alt" attribute on images

We've added a default `alt=''` attribute for the images that don't explicitly have `alt` tags, since for some screen readers, the default behavior is to read the `src` attribute of the element, and we don't want that.

- lack of "meta description"
- insecure external links

Most modern browsers support "noopener", though for completeness it's still common to combine it with "noreferrer" for support in older browsers. This addition is to prevent clickjacking vulnerabilities.